### PR TITLE
Fix typo: 'ssh' field should be 'auth' in source-packages documentation

### DIFF
--- a/docs/source-packages.md
+++ b/docs/source-packages.md
@@ -177,7 +177,7 @@ Private keys can also be used by referencing a `Secret` resource:
     git:
       repo: git@github.com:example-org/example-repo.git
       authMethod: sshPrivateKey
-      ssh:
+      auth:
         apiVersion: v1
         kind: Secret
         name: ssh-private-key


### PR DESCRIPTION
I used `authMethod: sshPrivateKey` in source-packages and got the following error:

```
"failed to evaluate function: upstream team, auth method 'sshPrivateKey' require auth specification"
```

It appears that the field ssh in the documentation is incorrect and should be auth instead. 