### PR TITLE
Support for array values in Fleet for source-packages function

### DIFF
--- a/pkg/kpt/kpt.go
+++ b/pkg/kpt/kpt.go
@@ -103,7 +103,7 @@ func toYAML(v interface{}) string {
 
 func indent(spaces int, v string) string {
 	pad := strings.Repeat(" ", spaces)
-	return strings.Replace(v, "\n", "\n"+pad, -1)
+	return strings.ReplaceAll(v, "\n", "\n"+pad)
 }
 
 func writeTemplated(templateString, filename string, data map[string]any) error {


### PR DESCRIPTION
`apply-setters` function allows the use of array values for parameters, as described [here](https://catalog.kpt.dev/apply-setters/v0.2/?id=setting-array-values).

However, when attempting to specify array values in `spec.packages.metadata.spec` of Fleet resource like this:

```yaml
apiVersion: fn.kpt.dev/v1alpha1
kind: Fleet
metadata:
  name: example-fleet
spec:
  packages:
  - name: foo
    metadata:
      spec:
        k10: |
          - v10
          - v11
          - v12
```

the following error occurs:

```
failed to evaluate function: /tmp/source-packages-2940720376/out/foo/bar/package-context.yaml: MalformedYAMLError: yaml: line 13: block sequence entries are not allowed in this context
```

This PR addresses this issue by enabling the use of array values in Fleet.
This enhancement will not only benefit `apply-setters` function but will also be useful for various other functions.