### PR TITLE
add helm ism for helm-upgrader semvers

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -61,7 +61,7 @@ test-helm-upgrader:
 	grep -e '.*upgrade-available.0: .*cert-manager:v1.12.1' test-out.txt
 	grep -e '.*upgrade-available.0: .*metacontroller-helm:v4.10.0' test-out.txt
 	grep -e '.*upgrade-available.0: .*karpenter:0.35.0' test-out.txt
-	grep -e '.*upgrade-available.1: .*/external-secrets:0.10.4' test-out.txt
+	grep -e '.*upgrade-available.1: .*/external-secrets:0.10.5' test-out.txt
 	rm test-out.txt
 	rm -rf tmp-results
 

--- a/cmd/helm-upgrader/main.go
+++ b/cmd/helm-upgrader/main.go
@@ -63,8 +63,14 @@ func evaluateChartVersion(chart *t.HelmChartArgs, upgradeConstraint string, user
 		return nil, nil, err
 	}
 
-	currChartRepoSearch = helm.GetSearch(search, chart.Version)
-	newChartRepoSearch = helm.GetSearch(search, newVersion)
+	currChartRepoSearch, err = helm.GetSearch(search, chart.Version)
+	if err != nil {
+		return nil, nil, err
+	}
+	newChartRepoSearch, err = helm.GetSearch(search, newVersion)
+	if err != nil {
+		return nil, nil, err
+	}
 	return currChartRepoSearch, newChartRepoSearch, nil
 }
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -239,12 +239,31 @@ func ToList(search []RepoSearch) []string {
 	return versions
 }
 
-// GetVersion looks up a specific chart version in repo-search
-func GetSearch(search []RepoSearch, version string) *RepoSearch {
+func lookupVersion(search []RepoSearch, version string) *RepoSearch {
 	for _, s := range search {
 		if s.Version == version {
 			return &s
 		}
 	}
 	return nil
+}
+
+// GetVersion looks up a specific chart version in repo-search
+func GetSearch(search []RepoSearch, version string) (*RepoSearch, error) {
+	s := lookupVersion(search, version)
+	if s != nil {
+		return s, nil
+	}
+	// Try some Helm isms for better error reporting
+	var alt string
+	if strings.HasPrefix(version, "v") {
+		alt = strings.TrimPrefix(version, "v")
+	} else {
+		alt = "v" + version
+	}
+	s = lookupVersion(search, alt)
+	if s != nil {
+		return nil, fmt.Errorf("version %v not found, did you mean %v", version, alt)
+	}
+	return nil, fmt.Errorf("version %v not found", version)
 }


### PR DESCRIPTION
This PR adds a Helm ism to how semvers are handled. I.e. semvers should not have a leading `v`, however this is often erroneously included. Helm often work irrespectively since it treats the leading `v` as optional. This PR will not make the `helm-upgrader` allow these semvers with a leading `v`, but the error message returned in case a given semver cannot be found have been improved. The `helm-upgrader` function continue to require exact version specification.