### PR TITLE
Increase max file size for render helm chart to 2 mb

### DIFF
--- a/Makefile.test
+++ b/Makefile.test
@@ -83,7 +83,7 @@ test-helm-upgrader:
 	grep -e '.*upgrade-available.0: .*cert-manager:v1.12.1' test-out.yaml
 	grep -e '.*upgrade-available.0: .*metacontroller-helm:v4.10.0' test-out.yaml
 	grep -e '.*upgrade-available.0: .*karpenter:0.35.0' test-out.yaml
-	grep -e '.*upgrade-available.1: .*/external-secrets:0.18.2' test-out.yaml
+	grep -e '.*upgrade-available.1: .*/external-secrets:0.19.1' test-out.yaml
 	rm test-out.yaml
 	rm -rf tmp-results
 

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	maxChartTemplateFileLength = 1024 * 1024
+	maxChartTemplateFileLength = 1024 * 2048
 )
 
 // Template extracts a chart tarball and renders the chart using given


### PR DESCRIPTION
This PR allows the render-helm-chart function to be able to render helm charts that have individual files that reach over 1 MB in size. Without this change, such files will simply be truncated. This is done silently which can cause errors when trying to apply to Kubernetes, or even worse, it will just apply faultlessly and be missing important resources (to the very great confusion of the user).